### PR TITLE
Remove unused aliases from tests

### DIFF
--- a/test/fulfillment_test.exs
+++ b/test/fulfillment_test.exs
@@ -1,7 +1,6 @@
 defmodule Peach.FulfillmentTest do
   use ExUnit.Case
   alias Peach.Fulfillment
-  alias Peach.Accounting.SalesOrder
   alias Peach.Sales
   import Plug.Conn
 

--- a/test/sales_test.exs
+++ b/test/sales_test.exs
@@ -1,10 +1,8 @@
 defmodule Peach.OrderTest do
   use ExUnit.Case
   import Plug.Conn
-  alias Peach.Accounting.SalesOrder
   alias Peach.Sales
   alias Peach.Db.Postgres, as: Db
-  import Moebius.DocumentQuery
 
   @order_args key: "test"
   @item sku: "honeymoon-mars", quantity: 1


### PR DESCRIPTION
These were emitting warnings:

```
warning: unused alias SalesOrder
  test/fulfillment_test.exs:4

warning: unused alias SalesOrder
  test/sales_test.exs:4

warning: unused import Moebius.DocumentQuery
  test/sales_test.exs:7
```
