### PR TITLE
status call deletion and replacement

### DIFF
--- a/lib/api.ex
+++ b/lib/api.ex
@@ -20,7 +20,7 @@ defmodule Peach.API do
   end
 
   rescue_from Unauthorized do
-    status 401
+    IO.inspect "401: Unauthorized"
     conn
       |> put_status(401)
       |> text("Unauthorized")


### PR DESCRIPTION
Changed code to match other status calls and prevent this error from happening:
== Compilation error on file lib/api.ex ==
** (CompileError) lib/api.ex:23: undefined function status/1
    (stdlib) lists.erl:1338: :lists.foreach/2
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6